### PR TITLE
[WIP] Add CentOS Stream 9 install instructions

### DIFF
--- a/install.md
+++ b/install.md
@@ -44,13 +44,14 @@ CRI-O also attempts to package for the following operating systems:
 ```
 Fedora 31+
 openSUSE
-CentOS 8
+CentOS 9 Stream
 CentOS 8 Stream
+CentOS 8
 CentOS 7
 Debian Unstable
 Debian Testing
-Debian 10
 Debian 11
+Debian 10
 Rasbian 10
 xUbuntu 22.04
 xUbuntu 21.10
@@ -97,8 +98,9 @@ To install on the following operating systems, set the environment variable $OS 
 
 | Operating system | $OS               |
 | ---------------- | ----------------- |
-| Centos 8         | `CentOS_8`        |
+| Centos 9 Stream  | `CentOS_9_Stream` |
 | Centos 8 Stream  | `CentOS_8_Stream` |
+| Centos 8         | `CentOS_8`        |
 | Centos 7         | `CentOS_7`        |
 
 And then run the following as root:


### PR DESCRIPTION
I've re-arranged all supported operating systems in descending order.  The intention is to add documentation to be able to use CentOS Stream 9.  Still waiting for clarification at issue  #6385. 

Signed-off-by: Renich Bon Ciric <renich@woralelandia.com>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
It helps users install cri-o on CentOS Stream 9.

#### Which issue(s) this PR fixes:

Fixes #6385

#### Does this PR introduce a user-facing change?

yes

```release-note
CentOS Stream 9 installation instructions have been added.
```
